### PR TITLE
Should not matter if a search is empty.

### DIFF
--- a/lib/src/query.dart
+++ b/lib/src/query.dart
@@ -92,7 +92,6 @@ class AlgoliaQuery {
   /// Source: [Learn more](https://www.algolia.com/doc/api-reference/api-parameters/query/)
   ///
   AlgoliaQuery search(String value) {
-    assert(value.isNotEmpty, 'value can not be empty');
     assert(!_parameters.containsKey('search'));
     return _copyWithParameters(<String, dynamic>{'query': value});
   }


### PR DESCRIPTION
#40 

Removing the requirement that search strings cannot be empty. Algolia has certain functionalities like pinned suggestions that this goes directly against.