### PR TITLE
Fix search (remove incorrect assertion)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.0.0+2
+
+* Remove incorrect assertion from `search`.
+
 ## [1.0.0+1] - Stable release with Null-Safety
 - Implemented ``analysis_options.yaml ``
 ## [1.0.0] - Stable release with Null-Safety

--- a/lib/src/query.dart
+++ b/lib/src/query.dart
@@ -92,7 +92,6 @@ class AlgoliaQuery {
   /// Source: [Learn more](https://www.algolia.com/doc/api-reference/api-parameters/query/)
   ///
   AlgoliaQuery search(String value) {
-    assert(value.isNotEmpty, 'value can not be empty');
     assert(!_parameters.containsKey('search'));
     return _copyWithParameters(<String, dynamic>{'query': value});
   }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: algolia
-version: 1.0.0+1
+version: 1.0.0+2
 description: >
    Algolia is a pure dart SDK, wrapped around Algolia REST API for easy implementation for your Flutter or Dart projects.
 homepage: https://github.com/knoxpo/dart_algolia


### PR DESCRIPTION
In the docs below, it clearly states that an empty search query will match all objects. Hence, this assertion was simply wrong.