### PR TITLE
Added queryID to QuerySnapshot

### DIFF
--- a/lib/src/query_snapshot.dart
+++ b/lib/src/query_snapshot.dart
@@ -20,6 +20,7 @@ class AlgoliaQuerySnapshot {
         processingTimeMS = map['processingTimeMS'],
         exhaustiveNbHits = map['exhaustiveNbHits'],
         query = map['query'],
+        queryId = map["queryID"],
         params = map['params'],
         facets = map['facets'] ?? {},
         facetsStats = map['facets_stats'] ?? {};
@@ -34,6 +35,7 @@ class AlgoliaQuerySnapshot {
   final int processingTimeMS;
   final bool exhaustiveNbHits;
   final String query;
+  final String queryId;
   final String params;
   final String index;
   final Map<String, dynamic> facets;


### PR DESCRIPTION
Having access tot the queryID is useful for Algolia Insights:
[Documentation](https://www.algolia.com/doc/rest-api/insights/#method-param-queryid)
Requires clickanalytics to be set to true to get this in the response.