### PR TITLE
Fix Insights API

### DIFF
--- a/lib/src/event_snapshot.dart
+++ b/lib/src/event_snapshot.dart
@@ -18,8 +18,8 @@ class AlgoliaEvent {
     required this.eventName,
     required this.index,
     required this.userToken,
-    this.queryId,
-    this.objectIds,
+    this.queryID,
+    this.objectIDs,
     this.timestamp,
     this.filters,
     this.positions,
@@ -33,16 +33,16 @@ class AlgoliaEvent {
           'eventName - Format: [a-zA-Z0-9_-]{1,64}',
         ),
         assert(
-          (objectIds?.isEmpty ?? true) || (filters?.isEmpty ?? true),
-          'An event can’t have both objectIds and filters at the same time.',
+          (objectIDs?.isEmpty ?? true) || (filters?.isEmpty ?? true),
+          'An event can’t have both objectIDs and filters at the same time.',
         ),
         assert(
-          !((queryId?.isNotEmpty ?? false) &&
+          !((queryID?.isNotEmpty ?? false) &&
                   eventType == AlgoliaEventType.click) ||
               ((positions?.isNotEmpty ?? false) &&
-                  (objectIds?.isNotEmpty ?? false) &&
-                  positions?.length == objectIds?.length),
-          'positions and objectIds field is required if a queryId is provided. '
+                  (objectIDs?.isNotEmpty ?? false) &&
+                  positions?.length == objectIDs?.length),
+          'positions and objectIDs field is required if a queryID is provided. '
           'One position must be provided for each objectId. '
           'Only include this parameter when sending click events.',
         );
@@ -71,30 +71,30 @@ class AlgoliaEvent {
   /// Time of the event expressed in milliseconds since the Unix epoch. Default: now()
   final DateTime? timestamp;
 
-  /// Algolia `queryId`. This is required when an event is tied to a search.
+  /// Algolia `queryID`. This is required when an event is tied to a search.
   ///
   /// It can be found in the Search API results response.
-  final String? queryId;
+  final String? queryID;
 
   /// An array of index `objectId`. Limited to 20 objects.
   ///
-  /// An event can’t have both `objectIds` and `filters` at the same time.
-  final List<String>? objectIds;
+  /// An event can’t have both `objectIDs` and `filters` at the same time.
+  final List<String>? objectIDs;
 
   /// An array of filters. Limited to 10 filters.
   ///
   /// **Format:**
   /// ${attribute}:${value}, like brand:apple.
   ///
-  /// An event can’t have both `objectIds` and `filters` at the same time.
+  /// An event can’t have both `objectIDs` and `filters` at the same time.
   final List<String>? filters;
 
   /// Position of the click in the list of Algolia search results.
   ///
   /// This field is
   /// **required**
-  /// if a `queryId` is provided. One position must be provided for each
-  /// `objectId`.
+  /// if a `queryID` is provided. One position must be provided for each
+  /// `objectID`.
   ///
   /// The position value must be absolute, not relative, to the result page.
   /// For example, when clicking on the third record of the second results page,
@@ -119,8 +119,8 @@ class AlgoliaEvent {
     if (timestamp != null) {
       body['timestamp'] = timestamp!.millisecondsSinceEpoch;
     }
-    if (queryId != null) body['queryId'] = queryId;
-    if (objectIds != null) body['objectIds'] = objectIds;
+    if (queryID != null) body['queryID'] = queryID;
+    if (objectIDs != null) body['objectIDs'] = objectIDs;
     if (filters != null) body['filters'] = filters;
     if (positions != null) body['positions'] = positions;
     return body;
@@ -132,8 +132,8 @@ class AlgoliaEvent {
     String? index,
     String? userToken,
     DateTime? timestamp,
-    String? queryId,
-    List<String>? objectIds,
+    String? queryID,
+    List<String>? objectIDs,
     List<String>? filters,
     List<int>? positions,
   }) {
@@ -143,8 +143,8 @@ class AlgoliaEvent {
       index: index ?? this.index,
       userToken: userToken ?? this.userToken,
       timestamp: timestamp ?? this.timestamp,
-      queryId: queryId ?? this.queryId,
-      objectIds: objectIds ?? this.objectIds,
+      queryID: queryID ?? this.queryID,
+      objectIDs: objectIDs ?? this.objectIDs,
       filters: filters ?? this.filters,
       positions: positions ?? this.positions,
     );
@@ -160,8 +160,8 @@ class AlgoliaEvent {
         other.index == index &&
         other.userToken == userToken &&
         other.timestamp == timestamp &&
-        other.queryId == queryId &&
-        other.objectIds.hashCode == objectIds.hashCode &&
+        other.queryID == queryID &&
+        other.objectIDs.hashCode == objectIDs.hashCode &&
         other.filters.hashCode == filters.hashCode &&
         other.positions.hashCode == positions.hashCode;
   }
@@ -173,14 +173,14 @@ class AlgoliaEvent {
         index.hashCode ^
         userToken.hashCode ^
         timestamp.hashCode ^
-        queryId.hashCode ^
-        objectIds.hashCode ^
+        queryID.hashCode ^
+        objectIDs.hashCode ^
         filters.hashCode ^
         positions.hashCode;
   }
 
   @override
   String toString() {
-    return 'AlgoliaEvent(eventType: $eventType, eventName: $eventName, index: $index, userToken: $userToken, timestamp: $timestamp, queryId: $queryId, objectIds: $objectIds, filters: $filters, positions: $positions)';
+    return 'AlgoliaEvent(eventType: $eventType, eventName: $eventName, index: $index, userToken: $userToken, timestamp: $timestamp, queryID: $queryID, objectIDs: $objectIDs, filters: $filters, positions: $positions)';
   }
 }

--- a/lib/src/query_snapshot.dart
+++ b/lib/src/query_snapshot.dart
@@ -17,7 +17,7 @@ class AlgoliaQuerySnapshot {
   final List<AlgoliaObjectSnapshot> hits;
 
   String get params => _map['params'];
-  String get queryId => _map['queryID'];
+  String? get queryId => _map['queryID'];
   String get query => _map['query'];
 
   bool get empty => hits.isEmpty;

--- a/lib/src/query_snapshot.dart
+++ b/lib/src/query_snapshot.dart
@@ -17,7 +17,7 @@ class AlgoliaQuerySnapshot {
   final List<AlgoliaObjectSnapshot> hits;
 
   String get params => _map['params'];
-  String? get queryId => _map['queryID'];
+  String? get queryID => _map['queryID'];
   String get query => _map['query'];
 
   bool get empty => hits.isEmpty;


### PR DESCRIPTION
The query ID can be null and the properties are named differently (see https://www.algolia.com/doc/rest-api/insights/).