### PR TITLE
Fix Algolia._apiCall returning Map<String, dynamic> instead of http.R…

### DIFF
--- a/lib/src/algolia.dart
+++ b/lib/src/algolia.dart
@@ -108,7 +108,7 @@ class Algolia {
     };
     try {
       var response = await action(0);
-      return json.decode(response.body);
+      return response;
     } catch (error) {
       try {
         var response = await action(1);


### PR DESCRIPTION
…esponse

It ends up failing [here](https://github.com/knoxpo/dart_algolia/blob/90df241b10b8bf635cefbf437bacc2b03fdd4f51/lib/src/query.dart#L82) when it expects an `http.Response` but gets `Map<String, dynamic>`.