### PR TITLE
Only send positions to Insights API when it's a click event

### DIFF
--- a/lib/src/event_snapshot.dart
+++ b/lib/src/event_snapshot.dart
@@ -126,7 +126,8 @@ class AlgoliaEvent {
     if (queryID != null) body['queryID'] = queryID;
     if (objectIDs != null) body['objectIDs'] = objectIDs;
     if (filters != null) body['filters'] = filters;
-    if (positions != null) body['positions'] = positions;
+    // Only send positions when click event.
+    if (eventType == AlgoliaEventType.click && positions != null) body['positions'] = positions;
     return body;
   }
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: algolia
 description: >
    Algolia is a pure dart SDK, wrapped around Algolia REST API for easy implementation for your Flutter or Dart projects.
-version: 1.0.4
+version: 1.0.5
 repository: https://github.com/knoxpo/dart_algolia
 homepage: https://knoxpo.com/knoxpo/dart_algolia
 


### PR DESCRIPTION
Sending `positions` on events other than the `click` event will result in errors.

