### PR TITLE
Fix Multiple query error with int as query value 

### DIFF
--- a/lib/src/index_reference.dart
+++ b/lib/src/index_reference.dart
@@ -359,7 +359,12 @@ class AlgoliaMultiIndexesReference {
       scheme: '',
       host: '',
       path: '',
-      queryParameters: data as Map<String, dynamic>?,
+      queryParameters: (data as Map<String, dynamic>?)?.map((key, value) {
+        if (value is List) {
+          return MapEntry(key, value);
+        }
+        return MapEntry(key, value.toString());
+      }),
     );
     return outgoingUri.toString().substring(3);
   }


### PR DESCRIPTION
Add condition to _encodeMap methods due to dart URI that only accept String or Iterable<String> for map value