### PR TITLE
feat(search): add custom params to requests

### DIFF
--- a/lib/src/query.dart
+++ b/lib/src/query.dart
@@ -2191,6 +2191,16 @@ class AlgoliaQuery {
     assert(!_parameters.containsKey('enableABTest'));
     return _copyWithParameters(<String, dynamic>{'enableABTest': enabled});
   }
+
+  ///
+  /// **Custom Parameter**
+  ///
+  /// Adds a custom request parameter to the search query.
+  ///
+  AlgoliaQuery custom(String key, dynamic value) {
+    assert(!_parameters.containsKey(key));
+    return _copyWithParameters({key: value});
+  }
 }
 
 class BoundingBox {

--- a/test/algolia_test.dart
+++ b/test/algolia_test.dart
@@ -1583,4 +1583,19 @@ void main() async {
       print('\n\n');
     });
   });
+
+  test('Perform custom parameter', () async {
+    AlgoliaQuery query = algolia.instance.index('contacts');
+
+    query = query.custom('enableReRanking', true);
+
+    // Get Result/Objects
+    var snap = await query.getObjects();
+
+    // Checking if has [AlgoliaQuerySnapshot]
+    expect(snap.runtimeType, AlgoliaQuerySnapshot);
+
+    print('Params: ${snap.params}');
+    print('\n\n');
+  });
 }

--- a/test/algolia_test.dart
+++ b/test/algolia_test.dart
@@ -1,5 +1,6 @@
 import 'package:algolia/algolia.dart';
 import 'package:dotenv/dotenv.dart' show load, env;
+
 // ignore: invalid_annotation_target
 @Timeout(Duration(seconds: 60))
 import 'package:test/test.dart';
@@ -1594,6 +1595,7 @@ void main() async {
 
     // Checking if has [AlgoliaQuerySnapshot]
     expect(snap.runtimeType, AlgoliaQuerySnapshot);
+    expect(snap.params.contains('enableReRanking'), true);
 
     print('Params: ${snap.params}');
     print('\n\n');


### PR DESCRIPTION
This PR adds the possibility of adding custom parameters to a search request.
It helps users provide parameters not available yet through the package API and make the library future-proof.