### PR TITLE
Fix Type 'List<String>' is not a subtype of type 'String' in `AlgoliaMultiIndexesReference`

### DIFF
--- a/lib/src/index_reference.dart
+++ b/lib/src/index_reference.dart
@@ -359,11 +359,11 @@ class AlgoliaMultiIndexesReference {
       scheme: '',
       host: '',
       path: '',
-      queryParameters: (data as Map<String, dynamic>?)?.map((key, value) {
-        if (value is List) {
+      queryParameters: data.map((key, value) {
+        if (value is String) {
           return MapEntry(key, value);
         }
-        return MapEntry(key, value.toString());
+        return MapEntry(key, jsonEncode(value));
       }),
     );
     return outgoingUri.toString().substring(3);

--- a/test/algolia_test.dart
+++ b/test/algolia_test.dart
@@ -154,6 +154,11 @@ void main() async {
       // Perform multiple facetFilters
       queryA = queryA.facetFilter('status:published');
       queryA = queryA.facetFilter('isDelete:false');
+      queryA = queryA.facetFilter([
+        'email:johan.1@example.com',
+        'email:johan.2@example.com',
+      ]);
+
       try {
         // Get Result/Objects
         var snap = await algolia.multipleQueries


### PR DESCRIPTION
This PR fixes the following issue: https://github.com/knoxpo/dart_algolia/issues/115

I updated the `Perform Multiple Queries` test to verify that encoding the parameters won't throw an exception anymore.

It's basically the same fix that was suggested in this PR that was closed and never merged for some reason: https://github.com/knoxpo/dart_algolia/pull/25.