### PR TITLE
Fix tagFilters implementation, adding tagFilters with OR relations

### DIFF
--- a/example/example.dart
+++ b/example/example.dart
@@ -147,7 +147,7 @@ void main() async {
   AlgoliaSettings settingsData = settingsRef;
   settingsData =
       settingsData.setReplicas(const ['index_copy_1', 'index_copy_2']);
-  var setSettings = await settingsData.setSettings();
+  var setSettings = await settingsData.setSettings(forwardToReplicas: true);
 
   // Checking if has [AlgoliaTask]
   print('\n\n');

--- a/lib/src/index_reference.dart
+++ b/lib/src/index_reference.dart
@@ -87,7 +87,7 @@ class AlgoliaIndexReference extends AlgoliaQuery {
   }) async {
     var response = await algolia._apiCall(
       ApiRequestType.post,
-      'indexes/$encodedIndex/facets/${Uri.encodeFull(facetName)}/query',
+      'indexes/$encodedIndex/facets/${Uri.encodeComponent(facetName)}/query',
       data: {
         'params': params,
         'facetQuery': facetQuery,

--- a/lib/src/index_settings.dart
+++ b/lib/src/index_settings.dart
@@ -44,7 +44,7 @@ class AlgoliaSettings {
   final Algolia algolia;
   final String _index;
   final Map<String, dynamic> _parameters;
-  String get encodedIndex => Uri.encodeFull(_index);
+  String get encodedIndex => Uri.encodeComponent(_index);
 
   AlgoliaSettings _copyWithParameters(Map<String, dynamic> parameters) {
     return AlgoliaSettings._(
@@ -60,7 +60,7 @@ class AlgoliaSettings {
   String toString() {
     return {
       'url': '${algolia._host}indexes' +
-          (_index.isNotEmpty ? '/' + Uri.encodeFull(_index) : ''),
+          (_index.isNotEmpty ? '/' + Uri.encodeComponent(_index) : ''),
       'headers': algolia._headers,
       'parameters': _parameters,
     }.toString();

--- a/lib/src/index_settings.dart
+++ b/lib/src/index_settings.dart
@@ -66,12 +66,15 @@ class AlgoliaSettings {
     }.toString();
   }
 
-  Future<AlgoliaTask> setSettings() async {
+  Future<AlgoliaTask> setSettings({
+    required bool forwardToReplicas,
+  }) async {
     assert(
         _parameters.keys.isNotEmpty, 'No setting parameter to update found.');
     var response = await algolia._apiCall(
       ApiRequestType.put,
-      'indexes/$encodedIndex/settings',
+      'indexes/$encodedIndex/settings' +
+          (forwardToReplicas ? '?forwardToReplicas=true' : ''),
       data: _parameters,
     );
     Map<String, dynamic> body = json.decode(response.body);

--- a/lib/src/object_reference.dart
+++ b/lib/src/object_reference.dart
@@ -14,8 +14,8 @@ class AlgoliaObjectReference {
   String? get objectID => _objectId;
 
   String? get encodedObjectID =>
-      _objectId != null ? Uri.encodeComponent(_objectId!) : null;
-  String? get encodedIndex => _index != null ? Uri.encodeComponent(_index!) : null;
+      _objectId != null ? Uri.encodeComponent(_objectId) : null;
+  String? get encodedIndex => _index != null ? Uri.encodeComponent(_index) : null;
 
   /// Get the object referred to by this [AlgoliaObjectReference].
   ///

--- a/lib/src/object_reference.dart
+++ b/lib/src/object_reference.dart
@@ -14,8 +14,8 @@ class AlgoliaObjectReference {
   String? get objectID => _objectId;
 
   String? get encodedObjectID =>
-      _objectId != null ? Uri.encodeFull(_objectId!) : null;
-  String? get encodedIndex => _index != null ? Uri.encodeFull(_index!) : null;
+      _objectId != null ? Uri.encodeComponent(_objectId!) : null;
+  String? get encodedIndex => _index != null ? Uri.encodeComponent(_index!) : null;
 
   /// Get the object referred to by this [AlgoliaObjectReference].
   ///
@@ -47,7 +47,7 @@ class AlgoliaObjectReference {
       url += '/$encodedObjectID';
     }
     if (data['objectID'] != null && _objectId == null) {
-      url += "/${Uri.encodeFull(data['objectID'])}";
+      url += "/${Uri.encodeComponent(data['objectID'])}";
     } else if (data['objectID'] != null) {
       data.remove('objectID');
     }

--- a/lib/src/query.dart
+++ b/lib/src/query.dart
@@ -24,7 +24,7 @@ class AlgoliaQuery {
                   List<List<String>>.unmodifiable(<List<String>>[]),
               'numericFilters':
                   List<List<String>>.unmodifiable(<List<String>>[]),
-              'tagFilters': List<List<String>>.unmodifiable(<List<String>>[]),
+              'tagFilters': List<dynamic>.unmodifiable(<dynamic>[]),
             });
   final Algolia algolia;
   final String _index;
@@ -671,12 +671,20 @@ class AlgoliaQuery {
   /// Source: [Learn more](https://www.algolia.com/doc/api-reference/api-parameters/tagFilters/)
   ///
   AlgoliaQuery setTagFilter(String value) {
-    final tagFilters = List<String>.from(_parameters['tagFilters']);
-    assert(tagFilters.where((String item) => value == item).isEmpty,
+    final tagFilters = List<dynamic>.from(_parameters['tagFilters']);
+    assert(tagFilters.where((dynamic item) => value == item).isEmpty,
         'TagFilters $value already exists in this query');
-    tagFilters.add(value);
+    tagFilters.add([value]);
     return _copyWithParameters(<String, dynamic>{'tagFilters': tagFilters});
   }
+
+  AlgoliaQuery setTagFilterOneOf(List<String> oneOfValues) {
+    assert(oneOfValues.isNotEmpty);
+    final tagFilters = List<dynamic>.from(_parameters['tagFilters']);
+    tagFilters.add(List.unmodifiable([...oneOfValues]));
+    return _copyWithParameters(<String, dynamic>{'tagFilters': tagFilters});
+  }
+
 
   ///
   /// **sumOrFiltersScores**

--- a/lib/src/query.dart
+++ b/lib/src/query.dart
@@ -31,7 +31,7 @@ class AlgoliaQuery {
   final Map<String, dynamic> _parameters;
 
   Map<String, dynamic> get parameters => _parameters;
-  String get encodedIndex => Uri.encodeFull(_index);
+  String get encodedIndex => Uri.encodeComponent(_index);
 
   AlgoliaQuery _copyWithParameters(Map<String, dynamic> parameters) {
     return AlgoliaQuery._(

--- a/lib/src/synonyms_reference.dart
+++ b/lib/src/synonyms_reference.dart
@@ -32,7 +32,7 @@ class AlgoliaSynonymsReference {
   ///
   /// ID of the referenced index.
   ///
-  String get encodedIndex => Uri.encodeFull(index);
+  String get encodedIndex => Uri.encodeComponent(index);
 
   ///
   /// **Search synonyms**

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -5,351 +5,401 @@ packages:
     dependency: transitive
     description:
       name: _fe_analyzer_shared
-      url: "https://pub.dartlang.org"
+      sha256: "58826e40314219b223f4723dd4205845040161cdc2df3e6a1cdceed5d8165084"
+      url: "https://pub.dev"
     source: hosted
-    version: "47.0.0"
+    version: "63.0.0"
   analyzer:
     dependency: transitive
     description:
       name: analyzer
-      url: "https://pub.dartlang.org"
+      sha256: f85566ec7b3d25cbea60f7dd4f157c5025f2f19233ca4feeed33b616c78a26a3
+      url: "https://pub.dev"
     source: hosted
-    version: "4.7.0"
+    version: "6.1.0"
   args:
     dependency: transitive
     description:
       name: args
-      url: "https://pub.dartlang.org"
+      sha256: eef6c46b622e0494a36c5a12d10d77fb4e855501a91c1b9ef9339326e58f0596
+      url: "https://pub.dev"
     source: hosted
-    version: "2.3.1"
+    version: "2.4.2"
   async:
     dependency: transitive
     description:
       name: async
-      url: "https://pub.dartlang.org"
+      sha256: "947bfcf187f74dbc5e146c9eb9c0f10c9f8b30743e341481c1e2ed3ecc18c20c"
+      url: "https://pub.dev"
     source: hosted
-    version: "2.9.0"
+    version: "2.11.0"
   boolean_selector:
     dependency: transitive
     description:
       name: boolean_selector
-      url: "https://pub.dartlang.org"
+      sha256: "6cfb5af12253eaf2b368f07bacc5a80d1301a071c73360d746b7f2e32d762c66"
+      url: "https://pub.dev"
     source: hosted
     version: "2.1.1"
   collection:
     dependency: transitive
     description:
       name: collection
-      url: "https://pub.dartlang.org"
+      sha256: ee67cb0715911d28db6bf4af1026078bd6f0128b07a5f66fb2ed94ec6783c09a
+      url: "https://pub.dev"
     source: hosted
-    version: "1.17.0"
+    version: "1.18.0"
   convert:
     dependency: transitive
     description:
       name: convert
-      url: "https://pub.dartlang.org"
+      sha256: "0f08b14755d163f6e2134cb58222dd25ea2a2ee8a195e53983d57c075324d592"
+      url: "https://pub.dev"
     source: hosted
-    version: "3.1.0"
+    version: "3.1.1"
   coverage:
     dependency: transitive
     description:
       name: coverage
-      url: "https://pub.dartlang.org"
+      sha256: "2fb815080e44a09b85e0f2ca8a820b15053982b2e714b59267719e8a9ff17097"
+      url: "https://pub.dev"
     source: hosted
-    version: "1.6.2"
+    version: "1.6.3"
   crypto:
     dependency: transitive
     description:
       name: crypto
-      url: "https://pub.dartlang.org"
+      sha256: ff625774173754681d66daaf4a448684fb04b78f902da9cb3d308c19cc5e8bab
+      url: "https://pub.dev"
     source: hosted
-    version: "3.0.2"
+    version: "3.0.3"
   dotenv:
     dependency: "direct dev"
     description:
       name: dotenv
-      url: "https://pub.dartlang.org"
+      sha256: dc4c91d8d5e9e361803fc81e8ea7ba0f35be483b656837ea6b9a3c41df308c68
+      url: "https://pub.dev"
     source: hosted
     version: "3.0.0"
   file:
     dependency: transitive
     description:
       name: file
-      url: "https://pub.dartlang.org"
+      sha256: "5fc22d7c25582e38ad9a8515372cd9a93834027aacf1801cf01164dac0ffa08c"
+      url: "https://pub.dev"
     source: hosted
-    version: "6.1.4"
+    version: "7.0.0"
   frontend_server_client:
     dependency: transitive
     description:
       name: frontend_server_client
-      url: "https://pub.dartlang.org"
+      sha256: "408e3ca148b31c20282ad6f37ebfa6f4bdc8fede5b74bc2f08d9d92b55db3612"
+      url: "https://pub.dev"
     source: hosted
-    version: "2.1.3"
+    version: "3.2.0"
   glob:
     dependency: transitive
     description:
       name: glob
-      url: "https://pub.dartlang.org"
+      sha256: "0e7014b3b7d4dac1ca4d6114f82bf1782ee86745b9b42a92c9289c23d8a0ab63"
+      url: "https://pub.dev"
     source: hosted
-    version: "2.1.1"
+    version: "2.1.2"
   http:
     dependency: "direct main"
     description:
       name: http
-      url: "https://pub.dartlang.org"
+      sha256: "759d1a329847dd0f39226c688d3e06a6b8679668e350e2891a6474f8b4bb8525"
+      url: "https://pub.dev"
     source: hosted
-    version: "0.13.5"
+    version: "1.1.0"
   http_multi_server:
     dependency: transitive
     description:
       name: http_multi_server
-      url: "https://pub.dartlang.org"
+      sha256: "97486f20f9c2f7be8f514851703d0119c3596d14ea63227af6f7a481ef2b2f8b"
+      url: "https://pub.dev"
     source: hosted
     version: "3.2.1"
   http_parser:
     dependency: transitive
     description:
       name: http_parser
-      url: "https://pub.dartlang.org"
+      sha256: "2aa08ce0341cc9b354a498388e30986515406668dbcc4f7c950c3e715496693b"
+      url: "https://pub.dev"
     source: hosted
     version: "4.0.2"
   io:
     dependency: transitive
     description:
       name: io
-      url: "https://pub.dartlang.org"
+      sha256: "2ec25704aba361659e10e3e5f5d672068d332fc8ac516421d483a11e5cbd061e"
+      url: "https://pub.dev"
     source: hosted
     version: "1.0.4"
   js:
     dependency: transitive
     description:
       name: js
-      url: "https://pub.dartlang.org"
+      sha256: f2c445dce49627136094980615a031419f7f3eb393237e4ecd97ac15dea343f3
+      url: "https://pub.dev"
     source: hosted
-    version: "0.6.5"
+    version: "0.6.7"
   lints:
     dependency: "direct dev"
     description:
       name: lints
-      url: "https://pub.dartlang.org"
+      sha256: a2c3d198cb5ea2e179926622d433331d8b58374ab8f29cdda6e863bd62fd369c
+      url: "https://pub.dev"
     source: hosted
     version: "1.0.1"
   logging:
     dependency: transitive
     description:
       name: logging
-      url: "https://pub.dartlang.org"
+      sha256: "623a88c9594aa774443aa3eb2d41807a48486b5613e67599fb4c41c0ad47c340"
+      url: "https://pub.dev"
     source: hosted
-    version: "1.1.0"
+    version: "1.2.0"
   matcher:
     dependency: transitive
     description:
       name: matcher
-      url: "https://pub.dartlang.org"
+      sha256: "1803e76e6653768d64ed8ff2e1e67bea3ad4b923eb5c56a295c3e634bad5960e"
+      url: "https://pub.dev"
     source: hosted
-    version: "0.12.12"
+    version: "0.12.16"
   meta:
     dependency: "direct main"
     description:
       name: meta
-      url: "https://pub.dartlang.org"
+      sha256: "3c74dbf8763d36539f114c799d8a2d87343b5067e9d796ca22b5eb8437090ee3"
+      url: "https://pub.dev"
     source: hosted
-    version: "1.9.0"
+    version: "1.9.1"
   mime:
     dependency: transitive
     description:
       name: mime
-      url: "https://pub.dartlang.org"
+      sha256: e4ff8e8564c03f255408decd16e7899da1733852a9110a58fe6d1b817684a63e
+      url: "https://pub.dev"
     source: hosted
-    version: "1.0.3"
+    version: "1.0.4"
   node_preamble:
     dependency: transitive
     description:
       name: node_preamble
-      url: "https://pub.dartlang.org"
+      sha256: "6e7eac89047ab8a8d26cf16127b5ed26de65209847630400f9aefd7cd5c730db"
+      url: "https://pub.dev"
     source: hosted
-    version: "2.0.1"
+    version: "2.0.2"
   package_config:
     dependency: transitive
     description:
       name: package_config
-      url: "https://pub.dartlang.org"
+      sha256: "1c5b77ccc91e4823a5af61ee74e6b972db1ef98c2ff5a18d3161c982a55448bd"
+      url: "https://pub.dev"
     source: hosted
     version: "2.1.0"
   path:
     dependency: transitive
     description:
       name: path
-      url: "https://pub.dartlang.org"
+      sha256: "8829d8a55c13fc0e37127c29fedf290c102f4e40ae94ada574091fe0ff96c917"
+      url: "https://pub.dev"
     source: hosted
     version: "1.8.3"
   pool:
     dependency: transitive
     description:
       name: pool
-      url: "https://pub.dartlang.org"
+      sha256: "20fe868b6314b322ea036ba325e6fc0711a22948856475e2c2b6306e8ab39c2a"
+      url: "https://pub.dev"
     source: hosted
     version: "1.5.1"
   pub_semver:
     dependency: transitive
     description:
       name: pub_semver
-      url: "https://pub.dartlang.org"
+      sha256: "40d3ab1bbd474c4c2328c91e3a7df8c6dd629b79ece4c4bd04bee496a224fb0c"
+      url: "https://pub.dev"
     source: hosted
-    version: "2.1.3"
+    version: "2.1.4"
   shelf:
     dependency: transitive
     description:
       name: shelf
-      url: "https://pub.dartlang.org"
+      sha256: ad29c505aee705f41a4d8963641f91ac4cee3c8fad5947e033390a7bd8180fa4
+      url: "https://pub.dev"
     source: hosted
-    version: "1.4.0"
+    version: "1.4.1"
   shelf_packages_handler:
     dependency: transitive
     description:
       name: shelf_packages_handler
-      url: "https://pub.dartlang.org"
+      sha256: "89f967eca29607c933ba9571d838be31d67f53f6e4ee15147d5dc2934fee1b1e"
+      url: "https://pub.dev"
     source: hosted
-    version: "3.0.1"
+    version: "3.0.2"
   shelf_static:
     dependency: transitive
     description:
       name: shelf_static
-      url: "https://pub.dartlang.org"
+      sha256: a41d3f53c4adf0f57480578c1d61d90342cd617de7fc8077b1304643c2d85c1e
+      url: "https://pub.dev"
     source: hosted
-    version: "1.1.1"
+    version: "1.1.2"
   shelf_web_socket:
     dependency: transitive
     description:
       name: shelf_web_socket
-      url: "https://pub.dartlang.org"
+      sha256: "9ca081be41c60190ebcb4766b2486a7d50261db7bd0f5d9615f2d653637a84c1"
+      url: "https://pub.dev"
     source: hosted
-    version: "1.0.3"
+    version: "1.0.4"
   source_map_stack_trace:
     dependency: transitive
     description:
       name: source_map_stack_trace
-      url: "https://pub.dartlang.org"
+      sha256: "84cf769ad83aa6bb61e0aa5a18e53aea683395f196a6f39c4c881fb90ed4f7ae"
+      url: "https://pub.dev"
     source: hosted
     version: "2.1.1"
   source_maps:
     dependency: transitive
     description:
       name: source_maps
-      url: "https://pub.dartlang.org"
+      sha256: "708b3f6b97248e5781f493b765c3337db11c5d2c81c3094f10904bfa8004c703"
+      url: "https://pub.dev"
     source: hosted
-    version: "0.10.10"
+    version: "0.10.12"
   source_span:
     dependency: transitive
     description:
       name: source_span
-      url: "https://pub.dartlang.org"
+      sha256: "53e943d4206a5e30df338fd4c6e7a077e02254531b138a15aec3bd143c1a8b3c"
+      url: "https://pub.dev"
     source: hosted
-    version: "1.9.1"
+    version: "1.10.0"
   stack_trace:
     dependency: transitive
     description:
       name: stack_trace
-      url: "https://pub.dartlang.org"
+      sha256: "73713990125a6d93122541237550ee3352a2d84baad52d375a4cad2eb9b7ce0b"
+      url: "https://pub.dev"
     source: hosted
-    version: "1.10.0"
+    version: "1.11.1"
   stream_channel:
     dependency: transitive
     description:
       name: stream_channel
-      url: "https://pub.dartlang.org"
+      sha256: ba2aa5d8cc609d96bbb2899c28934f9e1af5cddbd60a827822ea467161eb54e7
+      url: "https://pub.dev"
     source: hosted
-    version: "2.1.1"
+    version: "2.1.2"
   string_scanner:
     dependency: transitive
     description:
       name: string_scanner
-      url: "https://pub.dartlang.org"
+      sha256: "556692adab6cfa87322a115640c11f13cb77b3f076ddcc5d6ae3c20242bedcde"
+      url: "https://pub.dev"
     source: hosted
-    version: "1.1.1"
+    version: "1.2.0"
   term_glyph:
     dependency: transitive
     description:
       name: term_glyph
-      url: "https://pub.dartlang.org"
+      sha256: a29248a84fbb7c79282b40b8c72a1209db169a2e0542bce341da992fe1bc7e84
+      url: "https://pub.dev"
     source: hosted
     version: "1.2.1"
   test:
     dependency: "direct dev"
     description:
       name: test
-      url: "https://pub.dartlang.org"
+      sha256: "9b0dd8e36af4a5b1569029949d50a52cb2a2a2fdaa20cebb96e6603b9ae241f9"
+      url: "https://pub.dev"
     source: hosted
-    version: "1.21.4"
+    version: "1.24.6"
   test_api:
     dependency: transitive
     description:
       name: test_api
-      url: "https://pub.dartlang.org"
+      sha256: "5c2f730018264d276c20e4f1503fd1308dfbbae39ec8ee63c5236311ac06954b"
+      url: "https://pub.dev"
     source: hosted
-    version: "0.4.12"
+    version: "0.6.1"
   test_core:
     dependency: transitive
     description:
       name: test_core
-      url: "https://pub.dartlang.org"
+      sha256: "4bef837e56375537055fdbbbf6dd458b1859881f4c7e6da936158f77d61ab265"
+      url: "https://pub.dev"
     source: hosted
-    version: "0.4.16"
+    version: "0.5.6"
   typed_data:
     dependency: transitive
     description:
       name: typed_data
-      url: "https://pub.dartlang.org"
+      sha256: facc8d6582f16042dd49f2463ff1bd6e2c9ef9f3d5da3d9b087e244a7b564b3c
+      url: "https://pub.dev"
     source: hosted
-    version: "1.3.1"
+    version: "1.3.2"
   universal_io:
     dependency: "direct main"
     description:
       name: universal_io
-      url: "https://pub.dartlang.org"
+      sha256: "1722b2dcc462b4b2f3ee7d188dad008b6eb4c40bbd03a3de451d82c78bba9aad"
+      url: "https://pub.dev"
     source: hosted
-    version: "2.0.4"
+    version: "2.2.2"
   uuid:
     dependency: "direct main"
     description:
       name: uuid
-      url: "https://pub.dartlang.org"
+      sha256: "648e103079f7c64a36dc7d39369cabb358d377078a051d6ae2ad3aa539519313"
+      url: "https://pub.dev"
     source: hosted
     version: "3.0.7"
   vm_service:
     dependency: transitive
     description:
       name: vm_service
-      url: "https://pub.dartlang.org"
+      sha256: "0fae432c85c4ea880b33b497d32824b97795b04cdaa74d270219572a1f50268d"
+      url: "https://pub.dev"
     source: hosted
-    version: "9.4.0"
+    version: "11.9.0"
   watcher:
     dependency: transitive
     description:
       name: watcher
-      url: "https://pub.dartlang.org"
+      sha256: "3d2ad6751b3c16cf07c7fca317a1413b3f26530319181b37e3b9039b84fc01d8"
+      url: "https://pub.dev"
     source: hosted
-    version: "1.0.2"
+    version: "1.1.0"
   web_socket_channel:
     dependency: transitive
     description:
       name: web_socket_channel
-      url: "https://pub.dartlang.org"
+      sha256: d88238e5eac9a42bb43ca4e721edba3c08c6354d4a53063afaa568516217621b
+      url: "https://pub.dev"
     source: hosted
-    version: "2.3.0"
+    version: "2.4.0"
   webkit_inspection_protocol:
     dependency: transitive
     description:
       name: webkit_inspection_protocol
-      url: "https://pub.dartlang.org"
+      sha256: "67d3a8b6c79e1987d19d848b0892e582dbb0c66c57cc1fef58a177dd2aa2823d"
+      url: "https://pub.dev"
     source: hosted
     version: "1.2.0"
   yaml:
     dependency: transitive
     description:
       name: yaml
-      url: "https://pub.dartlang.org"
+      sha256: "75769501ea3489fca56601ff33454fe45507ea3bfb014161abc3b43ae25989d5"
+      url: "https://pub.dev"
     source: hosted
-    version: "3.1.1"
+    version: "3.1.2"
 sdks:
-  dart: ">=2.17.0 <3.0.0"
+  dart: ">=3.0.0 <4.0.0"

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -5,186 +5,202 @@ packages:
     dependency: transitive
     description:
       name: _fe_analyzer_shared
-      sha256: "58826e40314219b223f4723dd4205845040161cdc2df3e6a1cdceed5d8165084"
+      sha256: "5b7468c326d2f8a4f630056404ca0d291ade42918f4a3c6233618e724f39da8e"
       url: "https://pub.dev"
     source: hosted
-    version: "63.0.0"
+    version: "92.0.0"
   analyzer:
     dependency: transitive
     description:
       name: analyzer
-      sha256: f85566ec7b3d25cbea60f7dd4f157c5025f2f19233ca4feeed33b616c78a26a3
+      sha256: "70e4b1ef8003c64793a9e268a551a82869a8a96f39deb73dea28084b0e8bf75e"
       url: "https://pub.dev"
     source: hosted
-    version: "6.1.0"
+    version: "9.0.0"
   args:
     dependency: transitive
     description:
       name: args
-      sha256: eef6c46b622e0494a36c5a12d10d77fb4e855501a91c1b9ef9339326e58f0596
+      sha256: d0481093c50b1da8910eb0bb301626d4d8eb7284aa739614d2b394ee09e3ea04
       url: "https://pub.dev"
     source: hosted
-    version: "2.4.2"
+    version: "2.7.0"
   async:
     dependency: transitive
     description:
       name: async
-      sha256: "947bfcf187f74dbc5e146c9eb9c0f10c9f8b30743e341481c1e2ed3ecc18c20c"
+      sha256: "758e6d74e971c3e5aceb4110bfd6698efc7f501675bcfe0c775459a8140750eb"
       url: "https://pub.dev"
     source: hosted
-    version: "2.11.0"
+    version: "2.13.0"
   boolean_selector:
     dependency: transitive
     description:
       name: boolean_selector
-      sha256: "6cfb5af12253eaf2b368f07bacc5a80d1301a071c73360d746b7f2e32d762c66"
+      sha256: "8aab1771e1243a5063b8b0ff68042d67334e3feab9e95b9490f9a6ebf73b42ea"
       url: "https://pub.dev"
     source: hosted
-    version: "2.1.1"
+    version: "2.1.2"
+  cli_config:
+    dependency: transitive
+    description:
+      name: cli_config
+      sha256: ac20a183a07002b700f0c25e61b7ee46b23c309d76ab7b7640a028f18e4d99ec
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.2.0"
   collection:
     dependency: transitive
     description:
       name: collection
-      sha256: ee67cb0715911d28db6bf4af1026078bd6f0128b07a5f66fb2ed94ec6783c09a
+      sha256: "2f5709ae4d3d59dd8f7cd309b4e023046b57d8a6c82130785d2b0e5868084e76"
       url: "https://pub.dev"
     source: hosted
-    version: "1.18.0"
+    version: "1.19.1"
   convert:
     dependency: transitive
     description:
       name: convert
-      sha256: "0f08b14755d163f6e2134cb58222dd25ea2a2ee8a195e53983d57c075324d592"
+      sha256: b30acd5944035672bc15c6b7a8b47d773e41e2f17de064350988c5d02adb1c68
       url: "https://pub.dev"
     source: hosted
-    version: "3.1.1"
+    version: "3.1.2"
   coverage:
     dependency: transitive
     description:
       name: coverage
-      sha256: "2fb815080e44a09b85e0f2ca8a820b15053982b2e714b59267719e8a9ff17097"
+      sha256: "5da775aa218eaf2151c721b16c01c7676fbfdd99cebba2bf64e8b807a28ff94d"
       url: "https://pub.dev"
     source: hosted
-    version: "1.6.3"
+    version: "1.15.0"
   crypto:
     dependency: transitive
     description:
       name: crypto
-      sha256: ff625774173754681d66daaf4a448684fb04b78f902da9cb3d308c19cc5e8bab
+      sha256: c8ea0233063ba03258fbcf2ca4d6dadfefe14f02fab57702265467a19f27fadf
       url: "https://pub.dev"
     source: hosted
-    version: "3.0.3"
+    version: "3.0.7"
   dotenv:
     dependency: "direct dev"
     description:
       name: dotenv
-      sha256: dc4c91d8d5e9e361803fc81e8ea7ba0f35be483b656837ea6b9a3c41df308c68
+      sha256: "379e64b6fc82d3df29461d349a1796ecd2c436c480d4653f3af6872eccbc90e1"
       url: "https://pub.dev"
     source: hosted
-    version: "3.0.0"
+    version: "4.2.0"
   file:
     dependency: transitive
     description:
       name: file
-      sha256: "5fc22d7c25582e38ad9a8515372cd9a93834027aacf1801cf01164dac0ffa08c"
+      sha256: a3b4f84adafef897088c160faf7dfffb7696046cb13ae90b508c2cbc95d3b8d4
       url: "https://pub.dev"
     source: hosted
-    version: "7.0.0"
+    version: "7.0.1"
+  fixnum:
+    dependency: transitive
+    description:
+      name: fixnum
+      sha256: b6dc7065e46c974bc7c5f143080a6764ec7a4be6da1285ececdc37be96de53be
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.1.1"
   frontend_server_client:
     dependency: transitive
     description:
       name: frontend_server_client
-      sha256: "408e3ca148b31c20282ad6f37ebfa6f4bdc8fede5b74bc2f08d9d92b55db3612"
+      sha256: f64a0333a82f30b0cca061bc3d143813a486dc086b574bfb233b7c1372427694
       url: "https://pub.dev"
     source: hosted
-    version: "3.2.0"
+    version: "4.0.0"
   glob:
     dependency: transitive
     description:
       name: glob
-      sha256: "0e7014b3b7d4dac1ca4d6114f82bf1782ee86745b9b42a92c9289c23d8a0ab63"
+      sha256: c3f1ee72c96f8f78935e18aa8cecced9ab132419e8625dc187e1c2408efc20de
       url: "https://pub.dev"
     source: hosted
-    version: "2.1.2"
+    version: "2.1.3"
   http:
     dependency: "direct main"
     description:
       name: http
-      sha256: "759d1a329847dd0f39226c688d3e06a6b8679668e350e2891a6474f8b4bb8525"
+      sha256: "87721a4a50b19c7f1d49001e51409bddc46303966ce89a65af4f4e6004896412"
       url: "https://pub.dev"
     source: hosted
-    version: "1.1.0"
+    version: "1.6.0"
   http_multi_server:
     dependency: transitive
     description:
       name: http_multi_server
-      sha256: "97486f20f9c2f7be8f514851703d0119c3596d14ea63227af6f7a481ef2b2f8b"
+      sha256: aa6199f908078bb1c5efb8d8638d4ae191aac11b311132c3ef48ce352fb52ef8
       url: "https://pub.dev"
     source: hosted
-    version: "3.2.1"
+    version: "3.2.2"
   http_parser:
     dependency: transitive
     description:
       name: http_parser
-      sha256: "2aa08ce0341cc9b354a498388e30986515406668dbcc4f7c950c3e715496693b"
+      sha256: "178d74305e7866013777bab2c3d8726205dc5a4dd935297175b19a23a2e66571"
       url: "https://pub.dev"
     source: hosted
-    version: "4.0.2"
+    version: "4.1.2"
   io:
     dependency: transitive
     description:
       name: io
-      sha256: "2ec25704aba361659e10e3e5f5d672068d332fc8ac516421d483a11e5cbd061e"
+      sha256: dfd5a80599cf0165756e3181807ed3e77daf6dd4137caaad72d0b7931597650b
       url: "https://pub.dev"
     source: hosted
-    version: "1.0.4"
+    version: "1.0.5"
   js:
     dependency: transitive
     description:
       name: js
-      sha256: f2c445dce49627136094980615a031419f7f3eb393237e4ecd97ac15dea343f3
+      sha256: "53385261521cc4a0c4658fd0ad07a7d14591cf8fc33abbceae306ddb974888dc"
       url: "https://pub.dev"
     source: hosted
-    version: "0.6.7"
+    version: "0.7.2"
   lints:
     dependency: "direct dev"
     description:
       name: lints
-      sha256: a2c3d198cb5ea2e179926622d433331d8b58374ab8f29cdda6e863bd62fd369c
+      sha256: a5e2b223cb7c9c8efdc663ef484fdd95bb243bff242ef5b13e26883547fce9a0
       url: "https://pub.dev"
     source: hosted
-    version: "1.0.1"
+    version: "6.0.0"
   logging:
     dependency: transitive
     description:
       name: logging
-      sha256: "623a88c9594aa774443aa3eb2d41807a48486b5613e67599fb4c41c0ad47c340"
+      sha256: c8245ada5f1717ed44271ed1c26b8ce85ca3228fd2ffdb75468ab01979309d61
       url: "https://pub.dev"
     source: hosted
-    version: "1.2.0"
+    version: "1.3.0"
   matcher:
     dependency: transitive
     description:
       name: matcher
-      sha256: "1803e76e6653768d64ed8ff2e1e67bea3ad4b923eb5c56a295c3e634bad5960e"
+      sha256: dc58c723c3c24bf8d3e2d3ad3f2f9d7bd9cf43ec6feaa64181775e60190153f2
       url: "https://pub.dev"
     source: hosted
-    version: "0.12.16"
+    version: "0.12.17"
   meta:
     dependency: "direct main"
     description:
       name: meta
-      sha256: "3c74dbf8763d36539f114c799d8a2d87343b5067e9d796ca22b5eb8437090ee3"
+      sha256: "23f08335362185a5ea2ad3a4e597f1375e78bce8a040df5c600c8d3552ef2394"
       url: "https://pub.dev"
     source: hosted
-    version: "1.9.1"
+    version: "1.17.0"
   mime:
     dependency: transitive
     description:
       name: mime
-      sha256: e4ff8e8564c03f255408decd16e7899da1733852a9110a58fe6d1b817684a63e
+      sha256: "41a20518f0cb1256669420fdba0cd90d21561e560ac240f26ef8322e45bb7ed6"
       url: "https://pub.dev"
     source: hosted
-    version: "1.0.4"
+    version: "2.0.0"
   node_preamble:
     dependency: transitive
     description:
@@ -197,42 +213,42 @@ packages:
     dependency: transitive
     description:
       name: package_config
-      sha256: "1c5b77ccc91e4823a5af61ee74e6b972db1ef98c2ff5a18d3161c982a55448bd"
+      sha256: f096c55ebb7deb7e384101542bfba8c52696c1b56fca2eb62827989ef2353bbc
       url: "https://pub.dev"
     source: hosted
-    version: "2.1.0"
+    version: "2.2.0"
   path:
     dependency: transitive
     description:
       name: path
-      sha256: "8829d8a55c13fc0e37127c29fedf290c102f4e40ae94ada574091fe0ff96c917"
+      sha256: "75cca69d1490965be98c73ceaea117e8a04dd21217b37b292c9ddbec0d955bc5"
       url: "https://pub.dev"
     source: hosted
-    version: "1.8.3"
+    version: "1.9.1"
   pool:
     dependency: transitive
     description:
       name: pool
-      sha256: "20fe868b6314b322ea036ba325e6fc0711a22948856475e2c2b6306e8ab39c2a"
+      sha256: "978783255c543aa3586a1b3c21f6e9d720eb315376a915872c61ef8b5c20177d"
       url: "https://pub.dev"
     source: hosted
-    version: "1.5.1"
+    version: "1.5.2"
   pub_semver:
     dependency: transitive
     description:
       name: pub_semver
-      sha256: "40d3ab1bbd474c4c2328c91e3a7df8c6dd629b79ece4c4bd04bee496a224fb0c"
+      sha256: "5bfcf68ca79ef689f8990d1160781b4bad40a3bd5e5218ad4076ddb7f4081585"
       url: "https://pub.dev"
     source: hosted
-    version: "2.1.4"
+    version: "2.2.0"
   shelf:
     dependency: transitive
     description:
       name: shelf
-      sha256: ad29c505aee705f41a4d8963641f91ac4cee3c8fad5947e033390a7bd8180fa4
+      sha256: e7dd780a7ffb623c57850b33f43309312fc863fb6aa3d276a754bb299839ef12
       url: "https://pub.dev"
     source: hosted
-    version: "1.4.1"
+    version: "1.4.2"
   shelf_packages_handler:
     dependency: transitive
     description:
@@ -245,106 +261,106 @@ packages:
     dependency: transitive
     description:
       name: shelf_static
-      sha256: a41d3f53c4adf0f57480578c1d61d90342cd617de7fc8077b1304643c2d85c1e
+      sha256: c87c3875f91262785dade62d135760c2c69cb217ac759485334c5857ad89f6e3
       url: "https://pub.dev"
     source: hosted
-    version: "1.1.2"
+    version: "1.1.3"
   shelf_web_socket:
     dependency: transitive
     description:
       name: shelf_web_socket
-      sha256: "9ca081be41c60190ebcb4766b2486a7d50261db7bd0f5d9615f2d653637a84c1"
+      sha256: "3632775c8e90d6c9712f883e633716432a27758216dfb61bd86a8321c0580925"
       url: "https://pub.dev"
     source: hosted
-    version: "1.0.4"
+    version: "3.0.0"
   source_map_stack_trace:
     dependency: transitive
     description:
       name: source_map_stack_trace
-      sha256: "84cf769ad83aa6bb61e0aa5a18e53aea683395f196a6f39c4c881fb90ed4f7ae"
+      sha256: c0713a43e323c3302c2abe2a1cc89aa057a387101ebd280371d6a6c9fa68516b
       url: "https://pub.dev"
     source: hosted
-    version: "2.1.1"
+    version: "2.1.2"
   source_maps:
     dependency: transitive
     description:
       name: source_maps
-      sha256: "708b3f6b97248e5781f493b765c3337db11c5d2c81c3094f10904bfa8004c703"
+      sha256: "190222579a448b03896e0ca6eca5998fa810fda630c1d65e2f78b3f638f54812"
       url: "https://pub.dev"
     source: hosted
-    version: "0.10.12"
+    version: "0.10.13"
   source_span:
     dependency: transitive
     description:
       name: source_span
-      sha256: "53e943d4206a5e30df338fd4c6e7a077e02254531b138a15aec3bd143c1a8b3c"
+      sha256: "254ee5351d6cb365c859e20ee823c3bb479bf4a293c22d17a9f1bf144ce86f7c"
       url: "https://pub.dev"
     source: hosted
-    version: "1.10.0"
+    version: "1.10.1"
   stack_trace:
     dependency: transitive
     description:
       name: stack_trace
-      sha256: "73713990125a6d93122541237550ee3352a2d84baad52d375a4cad2eb9b7ce0b"
+      sha256: "8b27215b45d22309b5cddda1aa2b19bdfec9df0e765f2de506401c071d38d1b1"
       url: "https://pub.dev"
     source: hosted
-    version: "1.11.1"
+    version: "1.12.1"
   stream_channel:
     dependency: transitive
     description:
       name: stream_channel
-      sha256: ba2aa5d8cc609d96bbb2899c28934f9e1af5cddbd60a827822ea467161eb54e7
+      sha256: "969e04c80b8bcdf826f8f16579c7b14d780458bd97f56d107d3950fdbeef059d"
       url: "https://pub.dev"
     source: hosted
-    version: "2.1.2"
+    version: "2.1.4"
   string_scanner:
     dependency: transitive
     description:
       name: string_scanner
-      sha256: "556692adab6cfa87322a115640c11f13cb77b3f076ddcc5d6ae3c20242bedcde"
+      sha256: "921cd31725b72fe181906c6a94d987c78e3b98c2e205b397ea399d4054872b43"
       url: "https://pub.dev"
     source: hosted
-    version: "1.2.0"
+    version: "1.4.1"
   term_glyph:
     dependency: transitive
     description:
       name: term_glyph
-      sha256: a29248a84fbb7c79282b40b8c72a1209db169a2e0542bce341da992fe1bc7e84
+      sha256: "7f554798625ea768a7518313e58f83891c7f5024f88e46e7182a4558850a4b8e"
       url: "https://pub.dev"
     source: hosted
-    version: "1.2.1"
+    version: "1.2.2"
   test:
     dependency: "direct dev"
     description:
       name: test
-      sha256: "9b0dd8e36af4a5b1569029949d50a52cb2a2a2fdaa20cebb96e6603b9ae241f9"
+      sha256: "8f0eb7fa76b7d05a4f3707e0dbd581babef5b0915ca508b757cf15d0cabb56cb"
       url: "https://pub.dev"
     source: hosted
-    version: "1.24.6"
+    version: "1.27.0"
   test_api:
     dependency: transitive
     description:
       name: test_api
-      sha256: "5c2f730018264d276c20e4f1503fd1308dfbbae39ec8ee63c5236311ac06954b"
+      sha256: "19a78f63e83d3a61f00826d09bc2f60e191bf3504183c001262be6ac75589fb8"
       url: "https://pub.dev"
     source: hosted
-    version: "0.6.1"
+    version: "0.7.8"
   test_core:
     dependency: transitive
     description:
       name: test_core
-      sha256: "4bef837e56375537055fdbbbf6dd458b1859881f4c7e6da936158f77d61ab265"
+      sha256: bad9916601a4f2ef6e4dbc466fb712e4b42cf4917c3fd428b018f51984fce13b
       url: "https://pub.dev"
     source: hosted
-    version: "0.5.6"
+    version: "0.6.13"
   typed_data:
     dependency: transitive
     description:
       name: typed_data
-      sha256: facc8d6582f16042dd49f2463ff1bd6e2c9ef9f3d5da3d9b087e244a7b564b3c
+      sha256: f9049c039ebfeb4cf7a7104a675823cd72dba8297f264b6637062516699fa006
       url: "https://pub.dev"
     source: hosted
-    version: "1.3.2"
+    version: "1.4.0"
   universal_io:
     dependency: "direct main"
     description:
@@ -357,49 +373,65 @@ packages:
     dependency: "direct main"
     description:
       name: uuid
-      sha256: "648e103079f7c64a36dc7d39369cabb358d377078a051d6ae2ad3aa539519313"
+      sha256: a11b666489b1954e01d992f3d601b1804a33937b5a8fe677bd26b8a9f96f96e8
       url: "https://pub.dev"
     source: hosted
-    version: "3.0.7"
+    version: "4.5.2"
   vm_service:
     dependency: transitive
     description:
       name: vm_service
-      sha256: "0fae432c85c4ea880b33b497d32824b97795b04cdaa74d270219572a1f50268d"
+      sha256: "45caa6c5917fa127b5dbcfbd1fa60b14e583afdc08bfc96dda38886ca252eb60"
       url: "https://pub.dev"
     source: hosted
-    version: "11.9.0"
+    version: "15.0.2"
   watcher:
     dependency: transitive
     description:
       name: watcher
-      sha256: "3d2ad6751b3c16cf07c7fca317a1413b3f26530319181b37e3b9039b84fc01d8"
+      sha256: "592ab6e2892f67760543fb712ff0177f4ec76c031f02f5b4ff8d3fc5eb9fb61a"
       url: "https://pub.dev"
     source: hosted
-    version: "1.1.0"
+    version: "1.1.4"
+  web:
+    dependency: transitive
+    description:
+      name: web
+      sha256: "868d88a33d8a87b18ffc05f9f030ba328ffefba92d6c127917a2ba740f9cfe4a"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.1.1"
+  web_socket:
+    dependency: transitive
+    description:
+      name: web_socket
+      sha256: "34d64019aa8e36bf9842ac014bb5d2f5586ca73df5e4d9bf5c936975cae6982c"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.0.1"
   web_socket_channel:
     dependency: transitive
     description:
       name: web_socket_channel
-      sha256: d88238e5eac9a42bb43ca4e721edba3c08c6354d4a53063afaa568516217621b
+      sha256: d645757fb0f4773d602444000a8131ff5d48c9e47adfe9772652dd1a4f2d45c8
       url: "https://pub.dev"
     source: hosted
-    version: "2.4.0"
+    version: "3.0.3"
   webkit_inspection_protocol:
     dependency: transitive
     description:
       name: webkit_inspection_protocol
-      sha256: "67d3a8b6c79e1987d19d848b0892e582dbb0c66c57cc1fef58a177dd2aa2823d"
+      sha256: "87d3f2333bb240704cd3f1c6b5b7acd8a10e7f0bc28c28dcf14e782014f4a572"
       url: "https://pub.dev"
     source: hosted
-    version: "1.2.0"
+    version: "1.2.1"
   yaml:
     dependency: transitive
     description:
       name: yaml
-      sha256: "75769501ea3489fca56601ff33454fe45507ea3bfb014161abc3b43ae25989d5"
+      sha256: b9da305ac7c39faa3f030eccd175340f968459dae4af175130b3fc47e40d76ce
       url: "https://pub.dev"
     source: hosted
-    version: "3.1.2"
+    version: "3.1.3"
 sdks:
-  dart: ">=3.0.0 <4.0.0"
+  dart: ">=3.10.0 <4.0.0"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -10,7 +10,7 @@ environment:
 
 dependencies:
   meta: ^1.6.0
-  http: ^0.13.0
+  http: ^1.1.0
   uuid: ^3.0.5
   universal_io: ^2.0.4
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -6,15 +6,15 @@ repository: https://github.com/knoxpo/dart_algolia
 homepage: https://www.algolia.com/doc/guides/building-search-ui/troubleshooting/faq/ios/#does-algolia-support-dart-and-flutter
 
 environment:
-  sdk: '>=2.12.0 <3.0.0'
+  sdk: '>=3.10.0 <4.0.0'
 
 dependencies:
-  meta: ^1.6.0
-  http: ^1.1.0
-  uuid: ^3.0.5
-  universal_io: ^2.0.4
+  meta: ">=1.7.0"
+  http: ">=1.6.0"
+  uuid: ">=4.5.0"
+  universal_io: ">=2.2.0"
 
 dev_dependencies:
-  lints: ^1.0.1
-  test: ^1.17.12
-  dotenv: ^3.0.0
+  lints: ^6.0.0
+  test: ^1.27.0
+  dotenv: ^4.2.0

--- a/test/algolia_test.dart
+++ b/test/algolia_test.dart
@@ -1,9 +1,15 @@
 import 'package:algolia/algolia.dart';
-import 'package:dotenv/dotenv.dart' show load, env;
+import 'package:dotenv/dotenv.dart';
 
 // ignore: invalid_annotation_target
 @Timeout(Duration(seconds: 60))
 import 'package:test/test.dart';
+
+late DotEnv env;
+void load() {
+  env = DotEnv(includePlatformEnvironment: true);
+  env.load();
+}
 
 class Application {
   static Algolia get algolia {
@@ -220,7 +226,7 @@ void main() async {
     test('Perform Delete Indexes.', () async {
       AlgoliaSettings settings = algolia.instance.index('contacts').settings;
       settings = settings.setReplicas(['contacts_copy_1', 'contacts_copy_2']);
-      final removeReplicas = await settings.setSettings();
+      final removeReplicas = await settings.setSettings(forwardToReplicas: true);
       await removeReplicas.waitTask();
       taskDeleteIndex = await algolia.instance.index('contacts').deleteIndex();
       // taskDeleteIndex =
@@ -326,7 +332,7 @@ void main() async {
           .settings
           .setSearchableAttributes(['name']);
 
-      var response = await settings.setSettings();
+      var response = await settings.setSettings(forwardToReplicas: true);
 
       // Checking if has [AlgoliaTask]
       expect(response.runtimeType, AlgoliaTask);
@@ -340,7 +346,7 @@ void main() async {
           .settings
           .setAttributesForFaceting(['name', 'searchable(email)']);
 
-      var response = await settings.setSettings();
+      var response = await settings.setSettings(forwardToReplicas: true);
 
       // Checking if has [AlgoliaTask]
       expect(response.runtimeType, AlgoliaTask);
@@ -354,7 +360,7 @@ void main() async {
           .settings
           .setUnRetrievableAttributes(['isDelete']);
 
-      var response = await settings.setSettings();
+      var response = await settings.setSettings(forwardToReplicas: true);
 
       // Checking if has [AlgoliaTask]
       expect(response.runtimeType, AlgoliaTask);
@@ -368,7 +374,7 @@ void main() async {
           .settings
           .setAttributesToRetrieve(['email']);
 
-      var response = await settings.setSettings();
+      var response = await settings.setSettings(forwardToReplicas: true);
 
       // Checking if has [AlgoliaTask]
       expect(response.runtimeType, AlgoliaTask);
@@ -388,7 +394,7 @@ void main() async {
       // Get Result/Objects
       var snap;
       try {
-        var task = await settings.setSettings();
+        var task = await settings.setSettings(forwardToReplicas: true);
         await task.waitTask();
         snap = await query.getObjects();
       } on AlgoliaError catch (err) {
@@ -407,7 +413,7 @@ void main() async {
       var settings =
           algolia.instance.index('contacts').settings.setRanking(['words']);
 
-      var response = await settings.setSettings();
+      var response = await settings.setSettings(forwardToReplicas: true);
 
       // Checking if has [AlgoliaTask]
       expect(response.runtimeType, AlgoliaTask);
@@ -421,7 +427,7 @@ void main() async {
           .settings
           .setCustomRanking(['asc(createdAt)']);
 
-      var response = await settings.setSettings();
+      var response = await settings.setSettings(forwardToReplicas: true);
 
       // Checking if has [AlgoliaTask]
       expect(response.runtimeType, AlgoliaTask);
@@ -485,7 +491,7 @@ void main() async {
       // Get Result/Objects
       var snap;
       try {
-        var task = await settings.setSettings();
+        var task = await settings.setSettings(forwardToReplicas: true);
         await task.waitTask();
         snap = await query.getObjects();
       } on AlgoliaError catch (err) {
@@ -592,7 +598,7 @@ void main() async {
           .settings
           .setAttributesToHighlight(['email']);
 
-      var response = await settings.setSettings();
+      var response = await settings.setSettings(forwardToReplicas: true);
 
       // Checking if has [AlgoliaTask]
       expect(response.runtimeType, AlgoliaTask);
@@ -606,7 +612,7 @@ void main() async {
           .settings
           .setAttributesToSnippet(['contact']);
 
-      var response = await settings.setSettings();
+      var response = await settings.setSettings(forwardToReplicas: true);
 
       // Checking if has [AlgoliaTask]
       expect(response.runtimeType, AlgoliaTask);
@@ -621,7 +627,7 @@ void main() async {
           .setHighlightPreTag('<em>')
           .setHighlightPostTag('</em>');
 
-      var response = await settings.setSettings();
+      var response = await settings.setSettings(forwardToReplicas: true);
 
       // Checking if has [AlgoliaTask]
       expect(response.runtimeType, AlgoliaTask);
@@ -635,7 +641,7 @@ void main() async {
           .settings
           .setRestrictHighlightAndSnippetArrays(enable: true);
 
-      var response = await settings.setSettings();
+      var response = await settings.setSettings(forwardToReplicas: true);
 
       // Checking if has [AlgoliaTask]
       expect(response.runtimeType, AlgoliaTask);
@@ -755,7 +761,7 @@ void main() async {
       var settings =
           algolia.instance.index('contacts').settings.setTypoTolerance(true);
 
-      await settings.setSettings();
+      await settings.setSettings(forwardToReplicas: true);
 
       AlgoliaQuery query = algolia.instance.index('contacts');
 
@@ -777,7 +783,7 @@ void main() async {
           .settings
           .setAllowTyposOnNumericTokens(false);
 
-      await settings.setSettings();
+      await settings.setSettings(forwardToReplicas: true);
 
       AlgoliaQuery query = algolia.instance.index('contacts');
 
@@ -800,7 +806,7 @@ void main() async {
           .setDisableTypoToleranceOnAttributes(
               ['status']).setSearchableAttributes(['status']);
 
-      var task = await settings.setSettings();
+      var task = await settings.setSettings(forwardToReplicas: true);
       await task.waitTask();
 
       AlgoliaQuery query = algolia.instance.index('contacts');
@@ -829,7 +835,7 @@ void main() async {
       // Get Result/Objects
       var snap;
       try {
-        snap = await settings.setSettings();
+        snap = await settings.setSettings(forwardToReplicas: true);
       } on AlgoliaError catch (err) {
         print(err.error);
       }
@@ -928,7 +934,7 @@ void main() async {
           .settings
           .setQueryLanguages(['es']).setIgnorePlurals(true);
 
-      await settings.setSettings();
+      await settings.setSettings(forwardToReplicas: true);
 
       AlgoliaQuery query = algolia.instance.index('contacts');
 
@@ -949,7 +955,7 @@ void main() async {
           .settings
           .setQueryLanguages(['es']).setRemoveStopWords(true);
 
-      await settings.setSettings();
+      await settings.setSettings(forwardToReplicas: true);
 
       AlgoliaQuery query = algolia.instance.index('contacts');
 
@@ -970,7 +976,7 @@ void main() async {
           .settings
           .setCamelCaseAttributes(['name']);
 
-      var response = await settings.setSettings();
+      var response = await settings.setSettings(forwardToReplicas: true);
 
       // Checking if has [AlgoliaTask]
       expect(response.runtimeType, AlgoliaTask);
@@ -991,7 +997,7 @@ void main() async {
 
       var response;
       try {
-        response = await settings.setSettings();
+        response = await settings.setSettings(forwardToReplicas: true);
       } on AlgoliaError catch (err) {
         print(err.error);
       }
@@ -1010,7 +1016,7 @@ void main() async {
 
       var response;
       try {
-        response = await settings.setSettings();
+        response = await settings.setSettings(forwardToReplicas: true);
       } on AlgoliaError catch (err) {
         print(err.error);
       }
@@ -1027,7 +1033,7 @@ void main() async {
           .settings
           .setQueryLanguages(['es', 'ja']);
 
-      var response = await settings.setSettings();
+      var response = await settings.setSettings(forwardToReplicas: true);
 
       // Checking if has [AlgoliaTask]
       expect(response.runtimeType, AlgoliaTask);
@@ -1041,7 +1047,7 @@ void main() async {
           .settings
           .setIndexLanguages(['es', 'ja']);
 
-      var response = await settings.setSettings();
+      var response = await settings.setSettings(forwardToReplicas: true);
 
       // Checking if has [AlgoliaTask]
       expect(response.runtimeType, AlgoliaTask);
@@ -1074,7 +1080,7 @@ void main() async {
           .settings
           .setEnableRules(enabled: true);
 
-      await settings.setSettings();
+      await settings.setSettings(forwardToReplicas: true);
 
       AlgoliaQuery query = algolia.instance.index('contacts');
 
@@ -1118,7 +1124,7 @@ void main() async {
           .setEnablePersonalization(enabled: true);
 
       try {
-        await settings.setSettings();
+        await settings.setSettings(forwardToReplicas: true);
       } on AlgoliaError catch (err) {
         print(err.error);
       }
@@ -1180,7 +1186,7 @@ void main() async {
           .setQueryType(QueryType.prefixLast);
 
       try {
-        await settings.setSettings();
+        await settings.setSettings(forwardToReplicas: true);
       } on AlgoliaError catch (err) {
         print(err.error);
       }
@@ -1212,7 +1218,7 @@ void main() async {
           .setRemoveWordsIfNoResults(RemoveWordsIfNoResults.none);
 
       try {
-        await settings.setSettings();
+        await settings.setSettings(forwardToReplicas: true);
       } on AlgoliaError catch (err) {
         print(err.error);
       }
@@ -1242,7 +1248,7 @@ void main() async {
           .settings
           .setDisablePrefixOnAttributes(['sku']);
 
-      var result = await settings.setSettings();
+      var result = await settings.setSettings(forwardToReplicas: true);
 
       // Checking if has [AlgoliaQuerySnapshot]
       expect(result.runtimeType, AlgoliaTask);
@@ -1256,7 +1262,7 @@ void main() async {
           .settings
           .setDisableExactOnAttributes(['email']);
 
-      var result = await settings.setSettings();
+      var result = await settings.setSettings(forwardToReplicas: true);
 
       // Checking if has [AlgoliaQuerySnapshot]
       expect(result.runtimeType, AlgoliaTask);
@@ -1271,7 +1277,7 @@ void main() async {
           .settings
           .setExactOnSingleWordQuery(ExactOnSingleWordQuery.attribute);
 
-      await settings.setSettings();
+      await settings.setSettings(forwardToReplicas: true);
 
       //Override default exact ranking criterion computation on single word query for the current search
       AlgoliaQuery query = algolia.instance.index('contacts');
@@ -1295,7 +1301,7 @@ void main() async {
           .settings
           .setNumericAttributesForFiltering(['quantity']);
 
-      var result = await settings.setSettings();
+      var result = await settings.setSettings(forwardToReplicas: true);
 
       expect(result.runtimeType, AlgoliaTask);
       print(result);
@@ -1308,7 +1314,7 @@ void main() async {
           .settings
           .setAllowCompressionOfIntegerArray(enabled: true);
 
-      var result = await settings.setSettings();
+      var result = await settings.setSettings(forwardToReplicas: true);
 
       expect(result.runtimeType, AlgoliaTask);
       print(result);
@@ -1322,7 +1328,7 @@ void main() async {
           .settings
           .setAttributeForDistinct('url');
 
-      var result = await settings.setSettings();
+      var result = await settings.setSettings(forwardToReplicas: true);
 
       expect(result.runtimeType, AlgoliaTask);
       print(result);
@@ -1333,7 +1339,7 @@ void main() async {
       var settings =
           algolia.instance.index('contacts').settings.setDistinct(value: 0);
 
-      var result = await settings.setSettings();
+      var result = await settings.setSettings(forwardToReplicas: true);
 
       expect(result.runtimeType, AlgoliaTask);
       print(result);
@@ -1429,7 +1435,7 @@ void main() async {
       var settings =
           algolia.instance.index('contacts').settings.setMaxFacetHits(10);
 
-      await settings.setSettings();
+      await settings.setSettings(forwardToReplicas: true);
 
       //Override default number of facet values to return during a search for facet values for the current search
       AlgoliaQuery query = algolia.instance.index('contacts');
@@ -1451,7 +1457,7 @@ void main() async {
           .settings
           .setAttributeCriteriaComputedByMinProximity(enabled: true);
 
-      var result = await settings.setSettings();
+      var result = await settings.setSettings(forwardToReplicas: true);
 
       // Checking if has [AlgoliaQuerySnapshot]
       expect(result.runtimeType, AlgoliaTask);


### PR DESCRIPTION
The current tagFilters implementation does not support OR relations, and it has implementation errors which should throw errors, but luckily dart/flutter does not throw (yet). This PR fixes both.

The bug fixed: _paramters['tagFilters'] is created as a List<List<String>> and is cast to a List<String>. Interestingly, this does not throw currently, but I guess there is no guarantee it will not throw one day.

The Feature added: Allow for a combination of AND and OR Tag filters such as:
```tag1 AND (tag2 OR tag3) AND (tag4 OR tag5) AND tag6```
this is created by defining tagFilters like this:
```json
{
  "tag1",
  [ "tag2", "tag3" ],
  [ "tag4", "tag5" ],
  "tag6"
}
```

would love to see this merged, thanks :)

_happy if somebody wants to add some docs above but didn't take the time as most other functions do not have serious docs anyway_